### PR TITLE
Add a PUT /ceremony endpoint to facilitate editing a running ceremony

### DIFF
--- a/coordinator-service/src/app.test.ts
+++ b/coordinator-service/src/app.test.ts
@@ -81,6 +81,54 @@ describe('app', () => {
         })
     })
 
+    describe('PUT /ceremony', () => {
+        it('updates ceremony', async () => {
+            let res
+
+            res = await chai.request(app).get('/ceremony')
+            expect(res).to.have.status(200)
+
+            const newCeremony = res.body.result
+            newCeremony.chunks[0].lockHolder = 'pat'
+
+            res = await chai
+                .request(app)
+                .put('/ceremony')
+                .set('authorization', 'dummy verifier0')
+                .send(newCeremony)
+            expect(res).to.have.status(200)
+
+            res = await chai.request(app).get('/ceremony')
+            expect(res).to.have.status(200)
+
+            newCeremony.version = 1
+            expect(res.body.result).to.deep.equal(newCeremony)
+        })
+
+        it('rejects invalid versions', async () => {
+            let res
+
+            res = await chai.request(app).get('/ceremony')
+            expect(res).to.have.status(200)
+
+            const originalCeremony = res.body.result
+            const newCeremony = JSON.parse(JSON.stringify(res.body.result))
+            newCeremony.version = 9999
+            newCeremony.chunks[0].lockHolder = 'pat'
+
+            res = await chai
+                .request(app)
+                .put('/ceremony')
+                .set('authorization', 'dummy verifier0')
+                .send(newCeremony)
+            expect(res).to.have.status(409)
+
+            res = await chai.request(app).get('/ceremony')
+            expect(res).to.have.status(200)
+            expect(res.body.result).to.deep.equal(originalCeremony)
+        })
+    })
+
     describe('GET /chunks/:id/lock', () => {
         it('locks unlocked chunk', async () => {
             const res = await chai

--- a/coordinator-service/src/app.ts
+++ b/coordinator-service/src/app.ts
@@ -1,3 +1,4 @@
+import bodyParser from 'body-parser'
 import express from 'express'
 
 import { ChunkStorage, Coordinator } from './coordinator'
@@ -29,6 +30,20 @@ export function initExpress({
             result: coordinator.getCeremony(),
             status: 'ok',
         })
+    })
+
+    app.put('/ceremony', auth, bodyParser.json(), (req, res) => {
+        const ceremony = req.body
+        logger.info('PUT /ceremony')
+        try {
+            coordinator.setCeremony(ceremony)
+            res.json({
+                status: 'ok',
+            })
+        } catch (err) {
+            logger.warn(err.message)
+            res.status(409).json({ status: 'error', message: err.message })
+        }
     })
 
     app.post('/chunks/:id/lock', auth, (req, res) => {

--- a/coordinator-service/src/coordinator.ts
+++ b/coordinator-service/src/coordinator.ts
@@ -2,6 +2,7 @@ import { Ceremony, ChunkData, LockedChunkData } from './ceremony'
 
 export interface Coordinator {
     getCeremony(): Ceremony
+    setCeremony(ceremony: Ceremony): void
     getChunk(chunkId: string): LockedChunkData
     tryLockChunk(chunkId: string, particpantId: string): boolean
     contributeChunk(

--- a/coordinator-service/src/disk-coordinator.ts
+++ b/coordinator-service/src/disk-coordinator.ts
@@ -51,6 +51,16 @@ export class DiskCoordinator implements Coordinator {
         return chunk
     }
 
+    setCeremony(newCeremony: Ceremony): void {
+        const ceremony = this._readDb()
+        if (ceremony.version !== newCeremony.version) {
+            throw new Error(
+                `New ceremony is out of date: ${ceremony.version} vs ${newCeremony.version}`,
+            )
+        }
+        this._writeDb(newCeremony)
+    }
+
     getChunk(chunkId: string): LockedChunkData {
         const ceremony = this._readDb()
         return DiskCoordinator._getChunk(ceremony, chunkId)


### PR DESCRIPTION
The coordinator-service does a compare-and-set with the cermony version to enable
operations like the following to be atomic (or fail):

* GET /ceremony
* edit result
* PUT /ceremony

For example, you can try to edit the cermony state with `vi` (or whatever):

```
./coordinator-client ctl --path=/ceremony --method=get | jq '.result' > state.json
vi state.json
./coordinator-client ctl --path=/ceremony --method=put --data=state.json
```

This only succeeds if the ceremony on the coordinator-server hasn't changed
between GET and PUT.