### PR TITLE
[Feature] modified participants in helm to allow limiting number deployed

### DIFF
--- a/helm/coordinator-service/templates/participant-deployment.yaml
+++ b/helm/coordinator-service/templates/participant-deployment.yaml
@@ -1,5 +1,5 @@
 {{ if $.Values.participant.enabled }}
-{{- range $index, $keyPair := .Values.participant.plumoKeys }}
+{{- range $index := until (int .Values.participant.numParticipants) }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/helm/coordinator-service/templates/participant-secret.yaml
+++ b/helm/coordinator-service/templates/participant-secret.yaml
@@ -1,6 +1,6 @@
 {{if $.Values.participant.enabled }}
 {{ if eq $.Values.participant.participationMode "verify" }}
-{{- range $index, $keyPair := .Values.participant.plumoKeys }}
+{{- range $index := until (int .Values.participant.numParticipants) }}
 ---
 apiVersion: v1
 kind: Secret
@@ -8,9 +8,11 @@ metadata:
   name: {{ tpl $.Values.participant.fullName $ }}-secret-{{ $index }}
 type: Opaque
 stringData:
+  {{- with index $.Values.participant.plumoKeys $index }}
   plumo.keys: |
-    {{ $keyPair.key }}
-  password: {{ $keyPair.password | quote }}
+    {{ .key }}
+  password: {{ .password }}
+  {{- end }}
 {{ end }}
 {{ end }}
 {{ end }}

--- a/helm/coordinator-service/values.yaml
+++ b/helm/coordinator-service/values.yaml
@@ -19,6 +19,7 @@ coordinator:
   initialVerifierAddresses: ""
 
 participant: 
+  numParticipants: 5
   enabled: false
   fullName: "plumo-verifier-{{$.Values.environment}}"
   image: 

--- a/helm/coordinator-service/values.yaml
+++ b/helm/coordinator-service/values.yaml
@@ -19,7 +19,7 @@ coordinator:
   initialVerifierAddresses: ""
 
 participant: 
-  numParticipants: 5
+  numParticipants: 1
   enabled: false
   fullName: "plumo-verifier-{{$.Values.environment}}"
   image: 

--- a/infrastructure-setup/terraform/modules/coordinator-stack/main.tf
+++ b/infrastructure-setup/terraform/modules/coordinator-stack/main.tf
@@ -30,6 +30,7 @@ locals {
         image = var.verifier_image
         tag   = var.verifier_image_tag
       }
+      numParticipants = var.verifier_count
       plumoKeys = [for pair in var.verifier_credentials : {
         key      = file(pair.path),
         password = pair.password

--- a/infrastructure-setup/terraform/modules/coordinator-stack/variables.tf
+++ b/infrastructure-setup/terraform/modules/coordinator-stack/variables.tf
@@ -45,6 +45,11 @@ variable "verifier_credentials" {
   }]
 }
 
+variable "verifier_count" {
+  type        = number
+  description = "The number of verifiers to deploy, must be less than or equal to number of keys passed."
+}
+
 variable "monitor_image" {
   type        = string
   description = "The image to use in the monitor deployment"


### PR DESCRIPTION
This allows verifier keys to be pre-allocated but prevent verifiers from being deployed until they are needed. 