### PR TITLE
Server handles phase

### DIFF
--- a/coordinator-service/src/app.test.ts
+++ b/coordinator-service/src/app.test.ts
@@ -211,26 +211,6 @@ describe('app', () => {
         })
     })
 
-    describe('GET /verifier/chunks', () => {
-        it('matches ceremony', async () => {
-            const res = await chai.request(app).get('/verifier/chunks')
-            expect(res).to.have.status(200)
-
-            const expected = {
-                chunks: [
-                    { lockHolder: null, chunkId: '2' },
-                    { lockHolder: null, chunkId: '4' },
-                ],
-                numNonContributed: 2,
-                parameters: {},
-                numChunks: 4,
-                maxLocks: 1,
-                shutdownSignal: false,
-            }
-            expect(res.body.result).to.deep.equal(expected)
-        })
-    })
-
     describe('GET /chunks/:id/info', () => {
         it('info for chunk 1', async () => {
             const res = await chai.request(app).get('/chunks/1/info')

--- a/coordinator-service/src/app.ts
+++ b/coordinator-service/src/app.ts
@@ -85,7 +85,7 @@ export function initExpress({
             const parameters = coordinator.getParameters()
             const maxLocks = coordinator.getMaxLocks()
             const shutdownSignal = coordinator.getShutdownSignal()
-	    const phase = coordinator.getPhase()
+            const phase = coordinator.getPhase()
             res.json({
                 status: 'ok',
                 result: {
@@ -96,7 +96,7 @@ export function initExpress({
                     numChunks,
                     maxLocks,
                     shutdownSignal,
-		    phase, 
+                    phase,
                 },
             })
         } catch (err) {
@@ -116,7 +116,7 @@ export function initExpress({
             const parameters = coordinator.getParameters()
             const maxLocks = coordinator.getMaxLocks()
             const shutdownSignal = coordinator.getShutdownSignal()
-	    const phase = coordinator.getPhase()
+            const phase = coordinator.getPhase()
             res.json({
                 status: 'ok',
                 result: {
@@ -127,7 +127,7 @@ export function initExpress({
                     numChunks,
                     maxLocks,
                     shutdownSignal,
-		    phase,
+                    phase,
                 },
             })
         } catch (err) {

--- a/coordinator-service/src/app.ts
+++ b/coordinator-service/src/app.ts
@@ -105,35 +105,6 @@ export function initExpress({
         }
     })
 
-    app.get('/verifier/chunks', (req, res) => {
-        const participantId = req.params.id
-        logger.debug(`GET /verifier/${participantId}/chunks`)
-        try {
-            const chunks = coordinator.getVerifierChunks()
-            const numNonContributed = chunks.length
-            const numChunks = coordinator.getNumChunks()
-            const parameters = coordinator.getParameters()
-            const maxLocks = coordinator.getMaxLocks()
-            const shutdownSignal = coordinator.getShutdownSignal()
-	    const phase = coordinator.getPhase()
-            res.json({
-                status: 'ok',
-                result: {
-                    chunks,
-                    numNonContributed,
-                    parameters,
-                    numChunks,
-                    maxLocks,
-                    shutdownSignal,
-		    phase, 
-                },
-            })
-        } catch (err) {
-            logger.warn(err.message)
-            res.status(400).json({ status: 'error', message: err.message })
-        }
-    })
-
     app.get('/verifier/:id/chunks', (req, res) => {
         const participantId = req.params.id
         logger.debug(`GET /verifier/${participantId}/chunks`)

--- a/coordinator-service/src/app.ts
+++ b/coordinator-service/src/app.ts
@@ -85,6 +85,7 @@ export function initExpress({
             const parameters = coordinator.getParameters()
             const maxLocks = coordinator.getMaxLocks()
             const shutdownSignal = coordinator.getShutdownSignal()
+	    const phase = coordinator.getPhase()
             res.json({
                 status: 'ok',
                 result: {
@@ -95,6 +96,7 @@ export function initExpress({
                     numChunks,
                     maxLocks,
                     shutdownSignal,
+		    phase, 
                 },
             })
         } catch (err) {
@@ -113,6 +115,7 @@ export function initExpress({
             const parameters = coordinator.getParameters()
             const maxLocks = coordinator.getMaxLocks()
             const shutdownSignal = coordinator.getShutdownSignal()
+	    const phase = coordinator.getPhase()
             res.json({
                 status: 'ok',
                 result: {
@@ -122,6 +125,7 @@ export function initExpress({
                     numChunks,
                     maxLocks,
                     shutdownSignal,
+		    phase, 
                 },
             })
         } catch (err) {
@@ -141,6 +145,7 @@ export function initExpress({
             const parameters = coordinator.getParameters()
             const maxLocks = coordinator.getMaxLocks()
             const shutdownSignal = coordinator.getShutdownSignal()
+	    const phase = coordinator.getPhase()
             res.json({
                 status: 'ok',
                 result: {
@@ -151,6 +156,7 @@ export function initExpress({
                     numChunks,
                     maxLocks,
                     shutdownSignal,
+		    phase,
                 },
             })
         } catch (err) {

--- a/coordinator-service/src/ceremony.ts
+++ b/coordinator-service/src/ceremony.ts
@@ -56,6 +56,7 @@ export interface Ceremony {
     round: number
     maxLocks: number
     shutdownSignal: boolean
+    phase: string
 }
 
 type DeepReadonly<T> = {

--- a/coordinator-service/src/coordinator.ts
+++ b/coordinator-service/src/coordinator.ts
@@ -36,6 +36,7 @@ export interface Coordinator {
     getRound(): number
     getChunk(chunkId: string): LockedChunkData
     getChunkDownloadInfo(chunkId: string): ChunkDownloadInfo
+    getPhase(): string
     tryLockChunk(chunkId: string, participantId: string): boolean
     tryUnlockChunk(chunkId: string, participantId: string): boolean
     contributeChunk({

--- a/coordinator-service/src/disk-coordinator.ts
+++ b/coordinator-service/src/disk-coordinator.ts
@@ -124,6 +124,10 @@ export class DiskCoordinator implements Coordinator {
             .map(({ chunkId }) => chunkId)
     }
 
+    getPhase(): string {
+	return this.db.phase
+    }
+
     addAttestation(att: Attestation, participantId: string): void {
         if (att.address != participantId) {
             throw new Error('adding attestation to wrong participant')

--- a/coordinator-service/src/disk-coordinator.ts
+++ b/coordinator-service/src/disk-coordinator.ts
@@ -125,7 +125,7 @@ export class DiskCoordinator implements Coordinator {
     }
 
     getPhase(): string {
-	return this.db.phase
+        return this.db.phase
     }
 
     addAttestation(att: Attestation, participantId: string): void {


### PR DESCRIPTION
This PR includes phase in the Ceremony struct, in addition to returning the stored phase in the `contributor/:id/chunks` and `verifier/:id/chunks` code paths. Also removes the redundant `/verifier/chunks` path. Tested by running end-to-end scripts in `cc3542c402e14e970d0eb8fa6cf5603815b1218a` of `snark-setup-operator`.